### PR TITLE
Ignore the z value automatically rather than raising an error in HandTrackingModule -> findDistance()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # CVZone
 
+[![Downloads](https://pepy.tech/badge/cvzone)](https://pepy.tech/project/cvzone)
+[![Downloads](https://pepy.tech/badge/cvzone/month)](https://pepy.tech/project/cvzone)
+[![Downloads](https://pepy.tech/badge/cvzone/week)](https://pepy.tech/project/cvzone)
+
+
 
 This is a Computer vision package that makes its easy to run Image processing and AI functions. At the core it uses [OpenCV](https://github.com/opencv/opencv) and [Mediapipe](https://github.com/google/mediapipe) libraries. 
 

--- a/cvzone/HandTrackingModule.py
+++ b/cvzone/HandTrackingModule.py
@@ -155,8 +155,8 @@ class HandDetector:
                  Line information
         """
 
-        x1, y1 = p1
-        x2, y2 = p2
+        x1, y1, _ = p1
+        x2, y2, _ = p2
         cx, cy = (x1 + x2) // 2, (y1 + y2) // 2
         length = math.hypot(x2 - x1, y2 - y1)
         info = (x1, y1, x2, y2, cx, cy)


### PR DESCRIPTION
Unpacking only two values from the points tuple forces the user to recreate a manipulated tuple before passing it to the function, ignoring the 3rd value by default makes the work flow more flexible.